### PR TITLE
fix(address): add name to the provided address

### DIFF
--- a/live-examples/html-examples/content-sectioning/address.html
+++ b/live-examples/html-examples/content-sectioning/address.html
@@ -1,4 +1,5 @@
 <address>
+  James Rockford
   2354 Pacific Coast Highway<br>
   California<br/>
   USA<br/>


### PR DESCRIPTION
The description for the `<address>` element says:

> … It should include the name of the person, people, or organization to which the contact information refers.

This commit adds a name to make it clear that one should be added.